### PR TITLE
Added Content Security Policy Headers.

### DIFF
--- a/apimanager/apimanager/settings.py
+++ b/apimanager/apimanager/settings.py
@@ -77,6 +77,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     # 'django.middleware.cache.UpdateCacheMiddleware',
+    'csp.middleware.CSPMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -87,6 +88,13 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     # 'django.middleware.cache.FetchFromCacheMiddleware',
 ]
+
+# Content Security Policy - External Urls for scripts, styles, and images should be included here
+
+CSP_IMG_SRC = ("'self'", 'https://static.openbankproject.com')
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'",'https://cdnjs.cloudflare.com') #Change 'unsafe-inline' later to use Nonces
+CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'", 'http://code.jquery.com', 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/', 'https://cdnjs.cloudflare.com')
+CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src']
 
 #cache the view page, we set 60s = 1m,
 # CACHE_MIDDLEWARE_SECONDS = 60


### PR DESCRIPTION
Added Content Security Policy Headers to the django settings file. In future, when outside resources are loaded (i.e. not coming from the API manager itself) they need to be added to the allowed sources in the settings file.
This mitigates against potentially harmful scripts being executed on the site (XSS).

Currently this commit uses the unsafe "unsafe-inline" sources for script and style. This will be changed in a future commit where nonces will be included.

References: 
https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
https://www.laac.dev/blog/content-security-policy-using-django/

