### PR TITLE
Add Content Security Policy Headers

### DIFF
--- a/apimanager/apimanager/settings.py
+++ b/apimanager/apimanager/settings.py
@@ -94,13 +94,12 @@ MIDDLEWARE = [
 # Or the whole static folder could be uploaded to github, this prevents API manager breaking when
 # we run it on a server that may not connect to these sites
 
-#TODO inline script and style attributes should be modified in the template base.html so that they 
-# are no longer inline, this allows us to remove the 'unsafe-inline' policy.
+# Inline styles loaded by jsoneditor.min.js have been allowed by adding their hashes to CSP_STYLE_SRC
 
 CSP_IMG_SRC = ("'self'", 'https://static.openbankproject.com')
-CSP_STYLE_SRC = ("'self'", "'unsafe-inline'",'https://cdnjs.cloudflare.com') #Change 'unsafe-inline' later to use Nonces
-CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'", 'http://code.jquery.com', 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/', 'https://cdnjs.cloudflare.com')
-CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src']
+CSP_STYLE_SRC = ("'self' 'sha256-z2a+NIknPDE7NIEqE1lfrnG39eWOhJXWsXHYGGNb5oU=' 'sha256-Dn0vMZLidJplZ4cSlBMg/F5aa7Vol9dBMHzBF4fGEtk=' 'sha256-sA0hymKbXmMTpnYi15KmDw4u6uRdLXqHyoYIaORFtjU=' 'sha256-jUuiwf3ITuJc/jfynxWHLwTZifHIlhddD8NPmmVBztk=' 'sha256-RqzjtXRBqP4i+ruV3IRuHFq6eGIACITqGbu05VSVXsI='", 'https://cdnjs.cloudflare.com', )
+CSP_SCRIPT_SRC = ("'self'", 'http://code.jquery.com', 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/', 'https://cdnjs.cloudflare.com', "'unsafe-hashes'")
+CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src'] 
 
 #cache the view page, we set 60s = 1m,
 # CACHE_MIDDLEWARE_SECONDS = 60
@@ -137,7 +136,8 @@ TEMPLATES = [
                 'base.context_processors.api_tester_url',
                 'base.context_processors.portal_page',
                 'base.context_processors.logo_url',
-                'base.context_processors.override_css_url'
+                'base.context_processors.override_css_url',
+                'csp.context_processors.nonce'
             ],
         },
     },

--- a/apimanager/apimanager/settings.py
+++ b/apimanager/apimanager/settings.py
@@ -96,10 +96,12 @@ MIDDLEWARE = [
 
 # Inline styles loaded by jsoneditor.min.js have been allowed by adding their hashes to CSP_STYLE_SRC
 
-CSP_IMG_SRC = ("'self'", 'https://static.openbankproject.com')
+CSP_IMG_SRC = ("'self' data:", 'https://static.openbankproject.com')
 CSP_STYLE_SRC = ("'self' 'sha256-z2a+NIknPDE7NIEqE1lfrnG39eWOhJXWsXHYGGNb5oU=' 'sha256-Dn0vMZLidJplZ4cSlBMg/F5aa7Vol9dBMHzBF4fGEtk=' 'sha256-sA0hymKbXmMTpnYi15KmDw4u6uRdLXqHyoYIaORFtjU=' 'sha256-jUuiwf3ITuJc/jfynxWHLwTZifHIlhddD8NPmmVBztk=' 'sha256-RqzjtXRBqP4i+ruV3IRuHFq6eGIACITqGbu05VSVXsI='", 'https://cdnjs.cloudflare.com', )
-CSP_SCRIPT_SRC = ("'self'", 'http://code.jquery.com', 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/', 'https://cdnjs.cloudflare.com', "'unsafe-hashes'")
-CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src'] 
+CSP_SCRIPT_SRC = ("'self' 'sha256-4Hr8ttnXaUA4A6o0hGi3NUGNP2Is3Ep0W+rvm+W7BAk=' 'sha256-GgQWQ4Ejk4g9XpAZJ4YxIgZDgp7CdQCmqjMOMh9hD2g=' 'sha256-05NIAwVBHkAzKcXTfkYqTnBPtkpX+AmQvM/raql3qo0='", 'http://code.jquery.com', 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/', 'https://cdnjs.cloudflare.com')
+CSP_FONT_SRC = ("'self'", 'http://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/fonts/') 
+CSP_FRAME_ANCESTORS = ("'self'")
+CSP_FORM_ACTION = ("'self'")
 
 #cache the view page, we set 60s = 1m,
 # CACHE_MIDDLEWARE_SECONDS = 60

--- a/apimanager/apimanager/settings.py
+++ b/apimanager/apimanager/settings.py
@@ -77,6 +77,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     # 'django.middleware.cache.UpdateCacheMiddleware',
+    'csp.middleware.CSPMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.locale.LocaleMiddleware',
@@ -87,6 +88,13 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     # 'django.middleware.cache.FetchFromCacheMiddleware',
 ]
+
+# Content Security Policy - External Urls for scripts, styles, and images should be included here
+
+CSP_IMG_SRC = ("'self'", 'https://static.openbankproject.com')
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'",'https://cdnjs.cloudflare.com') #Change 'unsafe-inline' later to use Nonces
+CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'", 'http://code.jquery.com', 'https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/', 'https://cdnjs.cloudflare.com')
+CSP_INCLUDE_NONCE_IN = ['script-src', 'style-src']
 
 #cache the view page, we set 60s = 1m,
 # CACHE_MIDDLEWARE_SECONDS = 60

--- a/apimanager/apimanager/settings.py
+++ b/apimanager/apimanager/settings.py
@@ -90,6 +90,12 @@ MIDDLEWARE = [
 ]
 
 # Content Security Policy - External Urls for scripts, styles, and images should be included here
+#TODO these outside scripts should really just be loaded when we run "manage.py collectstatic"
+# Or the whole static folder could be uploaded to github, this prevents API manager breaking when
+# we run it on a server that may not connect to these sites
+
+#TODO inline script and style attributes should be modified in the template base.html so that they 
+# are no longer inline, this allows us to remove the 'unsafe-inline' policy.
 
 CSP_IMG_SRC = ("'self'", 'https://static.openbankproject.com')
 CSP_STYLE_SRC = ("'self'", "'unsafe-inline'",'https://cdnjs.cloudflare.com') #Change 'unsafe-inline' later to use Nonces

--- a/apimanager/base/static/css/base.css
+++ b/apimanager/base/static/css/base.css
@@ -31,6 +31,9 @@ footer a:hover, .footer a:focus {
 	color: #fff;
 }
 
+.footer-content-wrapper {
+	cursor:pointer;
+}
 
 .navbar-brand img {
 	height: 20px;
@@ -72,6 +75,20 @@ footer a:hover, .footer a:focus {
 .navbar-btn {
     margin-left: 15px;
 	margin-top: -6px;
+}
+
+.navbar-inner {
+	margin-left:15% !important;
+}
+
+.navbar-nav {
+	margin-left:8rem;
+}
+
+.obp-home-button {
+	position:absolute;
+	margin-left: -70px !important;
+	top:-5px;
 }
 
 /*.dropdown-menu > .active > a, .dropdown-menu > .active > a:hover, .dropdown-menu > .active > a:active {*/
@@ -211,6 +228,12 @@ table.tablesorter thead tr .headerSortDown, table.tablesorter thead tr .headerSo
     margin-left:5rem;
     text-decoration: none !important;
 }
+
+.language-select > a {
+	color:#fff;
+	text-decoration: none !important;
+}
+
 #uk {
     cursor:pointer;
 }

--- a/apimanager/base/templates/base.html
+++ b/apimanager/base/templates/base.html
@@ -19,7 +19,7 @@
 
 <body>
         <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
-            <div style="margin-left:15% !important;">
+            <div class="navbar-inner">
                 <div class="navbar-header">
                     <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
 						<span class="sr-only">Toggle navigation</span>
@@ -29,8 +29,8 @@
 					</button>
                 </div>
                 <div id="navbar" class="collapse navbar-collapse">
-                    <ul class="nav navbar-nav" style="margin-left:8rem">
-                        <li> <a href="{% url 'home' %}" style="position:absolute; margin-left: -70px !important; top:-5px"><img src="{{ logo_url }}" alt="brand"></a></li>
+                    <ul class="nav navbar-nav">
+                        <li> <a class="obp-home-button" href="{% url 'home' %}"><img src="{{ logo_url }}" alt="brand"></a></li>
                         <li><a href="{{ API_PORTAL }}">{% trans "Home" %}</a></li>
                         {% url "consumers-index" as consumers_index_url %}
                         <li {% if consumers_index_url in request.path %} class="active" {% endif %}><a href="{{ consumers_index_url }}">{% trans "Consumers" %}</a></li>
@@ -107,7 +107,7 @@
                                 <p class="navbar-right button-select"><span id="navbar-login-username">{{API_USERNAME}}</span>&nbsp;&nbsp;<a href="/logout" class="btn btn-default">{% trans "Logout" %} </a></p>
                                 {% endif %}
                             </li>
-                        <li class="language-select language_underline_format"><a style="color:#fff; text-decoration: none !important;">Language
+                        <li class="language-select language_underline_format"><a>Language
                             <span id="gb">EN</span>
                             |
                             <span id="es">ES</span></a></li>
@@ -128,7 +128,7 @@
     {% endif %}
         <div class="container" id="body-container">
             {% block content %}{% endblock content %}
-            <div class="footer-content-wrapper" data-lift="WebUI.homePage" style="cursor:pointer">
+            <div class="footer-content-wrapper" data-lift="WebUI.homePage">
             </div>
         </div>
     <footer>

--- a/apimanager/customers/static/customers/css/customers.css
+++ b/apimanager/customers/static/customers/css/customers.css
@@ -6,3 +6,7 @@ input#id_kyc_status {
     width: auto;
     margin: -4px 0;
 }
+
+.displaynone {
+    display:none;
+}

--- a/apimanager/customers/templates/customers/create.html
+++ b/apimanager/customers/templates/customers/create.html
@@ -96,7 +96,7 @@
                     {{ form.date_of_birth_date }}
                 </div>
             </div>
-            <div class="col-xs-12 col-sm-4" style="display:none">
+            <div class="col-xs-12 col-sm-4 displaynone">
                 {% if form.date_of_birth_time.errors %}<div class="alert alert-danger">{{ form.date_of_birth_time.errors }}</div>{% endif %}
                 <div class="form-group">
                     {{ form.date_of_birth_time.label_tag }}


### PR DESCRIPTION
Content Security Policy (CSP) headers have been added. This can help mitigate against cross-site scripting (XSS) attacks by only allowing content from external URLs to be loaded if they have been approved in the django settings.py file. As such, any new links to outside resources must be added to the settings.py file.

Several inline styles in the template base.html that were not compliant with the CSP have been moved to base.css.   

New additions to API-Manager must comply with the CSP. This can be checked by running with web inspector and checking for errors.

References:
https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html
https://www.laac.dev/blog/content-security-policy-using-django/
https://www.digitalocean.com/community/tutorials/how-to-secure-your-django-application-with-a-content-security-policy