### PR TITLE
Add Secure Session Cookies

### DIFF
--- a/apimanager/apimanager/settings.py
+++ b/apimanager/apimanager/settings.py
@@ -282,6 +282,13 @@ SHOW_API_TESTER = False
 # Always save session$
 SESSION_SAVE_EVERY_REQUEST = True
 
+# Session Cookie Settings
+SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_AGE = 300
+SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+
+
 # Paths on API_HOST to OAuth
 OAUTH_TOKEN_PATH = '/oauth/initiate'
 OAUTH_AUTHORIZATION_PATH = '/oauth/authorize'


### PR DESCRIPTION
Cookies that are secure, have the HttpOnly flag, and a default timeout of 300s have been added. To change the timeout, change SESSION_COOKIE_AGE in the django settings.py file.

See Django docs for in-depth info:
https://docs.djangoproject.com/en/4.2/topics/http/sessions/#:~:text=If%20value%20is%20an%20integer,at%20that%20specific%20date%2Ftime.